### PR TITLE
add babel-plugin-transform-es2015-arrow-functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   plugins: [
     'transform-es2015-modules-commonjs',
-    'transform-flow-strip-types'
+    'transform-flow-strip-types',
+    'transform-es2015-arrow-functions'
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@lttb/eslint-config-default": "github:lttb/configs#js",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "eslint": "^3.13.0",


### PR DESCRIPTION
When added this lib into project (directly or via [jss-styled](https://github.com/cssinjs/styled-jss)) `react-scripts build` always failed with error: 

```bash
static/js/1.9d0c9b4b.chunk.js from UglifyJs
SyntaxError: Unexpected token: operator (>) [../rockey/packages/rockey-react/~/is-react-prop/lib/index.js:38,0]
```

add [babel-plugin-transform-es2015-arrow-functions](https://babeljs.io/docs/plugins/transform-es2015-arrow-functions/) to fix this error
